### PR TITLE
Don't fail silently on invalid json

### DIFF
--- a/output.js
+++ b/output.js
@@ -16,7 +16,7 @@ function getBasePackage(filename, callback) {
       try {
         pkgJson = JSON.parse(data);
       } catch (e) {
-        pkgJson = {};
+        callback(new Error('Input is not valid json'), null);
       }
       callback(null, pkgJson);
     });


### PR DESCRIPTION
Without this change, when the input is invalid json, it's entirely ignored, without any warning to the user.
