### PR TITLE
Multiple fixes

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -18,8 +18,7 @@ function analyze(options, callback) {
     var rel = path.relative(cwd, dir);
 
     // don't process any `node_modules` directories
-    var nodeModules = 'node_modules';
-    if (nodeModules === rel.substring(0, nodeModules.length)) {
+    if (rel.includes('node_modules)) {
       log.verbose('analyze', 'skipping `node_modules` directory: %s', dir);
       return;
     }

--- a/analyze.js
+++ b/analyze.js
@@ -18,7 +18,7 @@ function analyze(options, callback) {
     var rel = path.relative(cwd, dir);
 
     // don't process any `node_modules` directories
-    if (rel.includes('node_modules)) {
+    if (rel.includes('node_modules')) {
       log.verbose('analyze', 'skipping `node_modules` directory: %s', dir);
       return;
     }

--- a/output.js
+++ b/output.js
@@ -5,6 +5,9 @@ var concat = require('concat-stream');
 function getBasePackage(filename, callback) {
   var stream;
   if (filename) {
+    if (!fs.existsSync(filename)) {
+      fs.closeSync(fs.openSync(filename, 'w'));
+    }
     stream = fs.createReadStream(filename);
   } else if (!process.stdin.isTTY) {
     stream = process.stdin;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "commander": "2.2.0",
     "concat-stream": "1.4.6",
     "dive": "0.3.0",
-    "graceful-fs": "3.0.2",
+    "graceful-fs": "^4.0.0",
     "npmenv": "0.0.1",
     "npmlog": "~0.1.1"
   },


### PR DESCRIPTION
Old logic was not able to skip `node_modules` folders in nested directories.

New logic checks is the path string includes the word `node_modules` and is more reliable.

Update graceful-fs dependency to work with newer versions of node.

Fixes #7 